### PR TITLE
fix(build): skip Crashlytics tasks on fdroid variants

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,3 +108,14 @@ dependencies {
 
 // google-services is already applied via the plugins {} block above.
 apply plugin: 'com.google.firebase.crashlytics'
+
+// Crashlytics applies globally, but fdroid ships no google-services.json
+// (see googleServices.missingGoogleServicesStrategy above). Disable its
+// per-variant tasks for fdroid so they don't fail looking up the appId.
+android.applicationVariants.configureEach { variant ->
+    if (variant.flavorName == 'fdroid') {
+        def suffix = variant.name.capitalize()
+        tasks.matching { it.name.contains('Crashlytics') && it.name.endsWith(suffix) }
+                .configureEach { enabled = false }
+    }
+}


### PR DESCRIPTION
## Summary
- `assembleFdroid*` failed with `Resource file containing the Google appId not found ... processFdroidReleaseGoogleServices/values/values.xml` because the Firebase Crashlytics Gradle plugin is applied at the project level and ran its `injectCrashlyticsMappingFileId` / `uploadCrashlyticsMappingFile` tasks against the `fdroid` variant.
- The `fdroid` flavor intentionally ships no `google-services.json` (gated by `googleServices.missingGoogleServicesStrategy = 'IGNORE'`), so no `values.xml` appId resource is generated and the inject task can't find it.
- Fix: disable any Crashlytics-named task whose name ends with an `fdroid` variant suffix via `applicationVariants.configureEach`. The `play` flavor's Crashlytics pipeline is untouched.

## Test plan
- [x] `./gradlew assembleFdroidDebug` succeeds; `injectCrashlyticsMappingFileIdFdroidDebug` shows `SKIPPED`.
- [x] `./gradlew assembleFdroidRelease` succeeds; `uploadCrashlyticsMappingFileFdroidRelease` shows `SKIPPED`.
- [ ] `./gradlew assemblePlayDebug` / `assemblePlayRelease` still run Crashlytics tasks normally (verify locally with a valid `google-services.json` + AdMob IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)